### PR TITLE
feat!: release v1 — graduate to stable major version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -63,6 +63,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           force-bump-patch-version: false
-          allow-initial-development-versions: true
+          allow-initial-development-versions: false
           changelog-file: true
           changelog-generator-opt: "emojis=true"


### PR DESCRIPTION
## Major version bump: v0.x → v1.0.0

This PR graduates `ioriver-go` to its first stable major release.

### Changes
- Set `allow-initial-development-versions: false` in the release workflow so that `BREAKING CHANGE` commits now trigger a real major version bump instead of a minor one.
- Empty breaking-change commit (`feat!: release v1`) to signal `go-semantic-release` to create `v1.0.0`.

### How it works
On merge to `master`, the CI workflow will:
1. Detect the `BREAKING CHANGE` footer in the commit message
2. With `allow-initial-development-versions: false`, bump the major version → **v1.0.0**
3. Create the GitHub release and `CHANGELOG.md` entry